### PR TITLE
Symbolise JSON keys

### DIFF
--- a/lib/alephant.rb
+++ b/lib/alephant.rb
@@ -52,7 +52,7 @@ module Alephant
     end
 
     def parse(msg)
-      JSON.parse(msg, { :symbolize_names => true })
+      JSON.parse(msg, :symbolize_names => true)
     end
 
     def write(data)

--- a/spec/alephant_spec.rb
+++ b/spec/alephant_spec.rb
@@ -175,7 +175,7 @@ describe Alephant::Alephant do
       Alephant::Sequencer.any_instance.stub(:sequential?).and_return(true)
       Alephant::Sequencer.any_instance.stub(:set_last_seen)
 
-      instance.should_receive(:write).with(JSON.parse(data, { :symbolize_names => true }))
+      instance.should_receive(:write).with(JSON.parse(data, :symbolize_names => true))
       instance.receive(msg)
     end
   end


### PR DESCRIPTION
Symbolise hash keys to save space and improve speed... (not tested...)

![symbol_keys_image](http://i.picasion.com/pic56/3d68a0629e0ffa1378e5cdc9553b0727.gif)
