### PR TITLE
Set empty hash as default when initializing Alephant::Views::Base

### DIFF
--- a/lib/alephant/views/base.rb
+++ b/lib/alephant/views/base.rb
@@ -4,7 +4,7 @@ module Alephant::Views
   class Base < Mustache
     attr_accessor :data
 
-    def initialize(data)
+    def initialize(data = {})
       @data = data
     end
 


### PR DESCRIPTION
Set an empty hash default for Alephant::Views::Base as a lot of our view models do this independently and this will reduce some of the initialisation setup we have.

This resolves #39 

![set_default_empty_hash_for_alephant_views_base](https://24.media.tumblr.com/0becf69bac07988c477f4df88259222f/tumblr_n146reyj5j1rj4v7ho1_500.gif)
